### PR TITLE
Update 0.1.22

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,0 +1,20 @@
+on:
+  pull_request:
+
+jobs:
+  test:
+    name: test
+    # Specify OS
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v2
+      - name: Install stable toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+      - run: cargo fmt --all -- --check
+      - run: cargo clippy --all-targets -- -D clippy::all
+      - run: cargo test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## Pre-alpha
 
+### 0.1.22
+- *BREAKING CHANGE* (minor)
+- Change input::mask::* types to u8 from usize
+- Add wave table memory address and size
+
 ### 0.1.21
 - Add MSWP for easy sprite management
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
 name = "maikor-platform"
-version = "0.1.21"
+version = "0.1.22"
 edition = "2021"
 authors = ["Ray Britton <raybritton@pm.me>"]
-description = "Maikor Platform (language, addresses, etc)"
+description = "Maikor Platform specifications (language, addresses, etc)"
 license = "MIT"
 repository = "https://github.com/MaikorAppPublic/platform"
 readme = "README.md"

--- a/src/input.rs
+++ b/src/input.rs
@@ -1,19 +1,19 @@
 /// Values to check against when a button is pressed
 pub mod mask {
     /// Bit mask for mem::INPUT
-    pub const UP: usize = 0b00000001;
-    pub const DOWN: usize = 0b00000010;
-    pub const LEFT: usize = 0b00000100;
-    pub const RIGHT: usize = 0b00001000;
+    pub const UP: u8 = 0b00000001;
+    pub const DOWN: u8 = 0b00000010;
+    pub const LEFT: u8 = 0b00000100;
+    pub const RIGHT: u8 = 0b00001000;
 
     /// Bit mask for mem::INPUT+1
-    pub const A: usize = 0b00000001;
-    pub const B: usize = 0b00000010;
-    pub const START: usize = 0b00000100;
-    pub const L: usize = 0b00001000;
-    pub const R: usize = 0b00010000;
-    pub const X: usize = 0b00100000;
-    pub const Y: usize = 0b01000000;
+    pub const A: u8 = 0b00000001;
+    pub const B: u8 = 0b00000010;
+    pub const START: u8 = 0b00000100;
+    pub const L: u8 = 0b00001000;
+    pub const R: u8 = 0b00010000;
+    pub const X: u8 = 0b00100000;
+    pub const Y: u8 = 0b01000000;
 }
 
 /// Type of the active controller

--- a/src/mem.rs
+++ b/src/mem.rs
@@ -6,6 +6,7 @@ pub mod sizes {
     pub const CODE: u16 = CODE_BANK * 2;
     pub const RAM: u16 = RAM_BANK * 2;
     pub const SOUND: u16 = 30;
+    pub const WAVE_TABLE: u16 = 16;
     //Byte 0 is direction, byte 1 is action
     pub const INPUT: u16 = 2;
     pub const CODE_BANK_ID: u16 = 1;
@@ -57,9 +58,9 @@ pub mod sizes {
         LAYER_TOTAL + SPRITE_TABLE + PALETTES_TOTAL + ATLAS_TOTAL + CONTROLLER_TOTAL;
     pub const SYSTEM_TOTAL: u16 =
         CODE + RAM + CODE_BANK_ID + RAM_BANK_ID + STACK + SP + FP + TIMERS + IRQ_INTERNAL + VLINE;
-    pub const HARDWARE_TOTAL: u16 =
+    pub const HARDWARE_TOTAL: u16 = WAVE_TABLE+
         SOUND + INPUT + SAVE_BANK_ID + SAVE_BANK + SAVE_CONTROL + DATETIME + RAND;
-    pub const RESERVED: u16 = 50;
+    pub const RESERVED: u16 = 34;
     pub const TOTAL: usize =
         (GRAPHICS_TOTAL + SYSTEM_TOTAL + HARDWARE_TOTAL) as usize + RESERVED as usize;
 }
@@ -105,7 +106,8 @@ pub mod address {
     pub const SAVE_CONTROL: u16 = 0xFBDE; //64478
     pub const DATETIME: u16 = 0xFBDF; //64479
     pub const RAND: u16 = 0xFBE5; //64485
-    pub const RESERVED: u16 = 0xFBE6; //64486
+    pub const WAVE_TABLE: u16 = 0xFBE6; //64486
+    pub const RESERVED: u16 = 0xFBF6; //64502
     pub const STACK: u16 = 0xFC18; //64536
     pub const MAX: u16 = 0xFFFF; //65535
 
@@ -151,12 +153,15 @@ pub mod interrupt_flags {
 
 #[cfg(test)]
 mod test {
-    use crate::mem::sizes::TOTAL;
+    use crate::mem::sizes::{RESERVED, TOTAL};
     use crate::mem::{address, sizes};
 
     #[test]
     fn test_values() {
         assert_eq!(TOTAL, 65536);
+        //the system needs at least 6 bytes available for internal use
+        //currently this is just VM::execute_op()
+        assert!(RESERVED > 6);
     }
 
     #[test]
@@ -267,7 +272,8 @@ mod test {
             address::SAVE_CONTROL + sizes::SAVE_CONTROL
         );
         assert_eq!(address::RAND, address::DATETIME + sizes::DATETIME);
-        assert_eq!(address::RESERVED, address::RAND + sizes::RAND);
+        assert_eq!(address::WAVE_TABLE, address::RAND + sizes::RAND);
+        assert_eq!(address::RESERVED, address::WAVE_TABLE + sizes::WAVE_TABLE);
         assert_eq!(address::STACK, address::RESERVED + sizes::RESERVED);
         assert_eq!(65536, address::STACK as usize + sizes::STACK as usize);
         assert_eq!(address::MAX, 0xFFFF);

--- a/src/mem.rs
+++ b/src/mem.rs
@@ -58,8 +58,8 @@ pub mod sizes {
         LAYER_TOTAL + SPRITE_TABLE + PALETTES_TOTAL + ATLAS_TOTAL + CONTROLLER_TOTAL;
     pub const SYSTEM_TOTAL: u16 =
         CODE + RAM + CODE_BANK_ID + RAM_BANK_ID + STACK + SP + FP + TIMERS + IRQ_INTERNAL + VLINE;
-    pub const HARDWARE_TOTAL: u16 = WAVE_TABLE+
-        SOUND + INPUT + SAVE_BANK_ID + SAVE_BANK + SAVE_CONTROL + DATETIME + RAND;
+    pub const HARDWARE_TOTAL: u16 =
+        WAVE_TABLE + SOUND + INPUT + SAVE_BANK_ID + SAVE_BANK + SAVE_CONTROL + DATETIME + RAND;
     pub const RESERVED: u16 = 34;
     pub const TOTAL: usize =
         (GRAPHICS_TOTAL + SYSTEM_TOTAL + HARDWARE_TOTAL) as usize + RESERVED as usize;
@@ -157,6 +157,7 @@ mod test {
     use crate::mem::{address, sizes};
 
     #[test]
+    #[allow(clippy::assertions_on_constants)] //these are used as safe guards against changes
     fn test_values() {
         assert_eq!(TOTAL, 65536);
         //the system needs at least 6 bytes available for internal use


### PR DESCRIPTION
- *BREAKING CHANGE* (minor)
- Change `input::mask::*` types to u8 from usize
- Add wave table memory address and size